### PR TITLE
fix #14: add windowPut--i.e. put with strategy based on num pending puts

### DIFF
--- a/src/Effect/AVar.purs
+++ b/src/Effect/AVar.purs
@@ -7,6 +7,8 @@ module Effect.AVar
   , take
   , tryTake
   , put
+  , Operation(..)
+  , windowPut
   , tryPut
   , read
   , tryRead
@@ -33,6 +35,17 @@ data AVarStatus a
   | Filled a
   | Empty
 
+data Operation
+  = Ignore -- Do nothing with the queue
+  | Fail Error -- Propagate an exception to the callback
+  | Halt Error -- Kill the internal queue and propagate the exception
+  | PushHead -- Push callback onto the head
+  | PushTail -- Push callback onto the tail
+  | DropHead Error -- Drop the head, and push onto the tail
+  | DropTail Error -- Drop the tail, and push onto the head
+  | SwapHead Error -- Replace the head
+  | SwapTail Error -- Replace the tail
+
 -- | Creates a new empty AVar.
 foreign import empty ∷ ∀ a. Effect (AVar a)
 
@@ -50,7 +63,51 @@ kill err avar = Fn.runFn3 _killVar ffiUtil err avar
 -- | the AVar becomes available. Returns an effect which will remove the
 -- | callback from the pending queue.
 put ∷ ∀ a. a → AVar a → AVarCallback Unit → Effect (Effect Unit)
-put value avar cb = Fn.runFn4 _putVar ffiUtil value avar cb
+put = windowPut (const PushTail)
+
+-- | Puts a value into an AVar using a strategy determined
+-- | dynamically on the basis of the number of pending puts
+-- | (i.e. not including the current value of the AVar, if non-EMPTY).
+windowPut
+  :: ∀ a
+   . (Int -> Operation)
+  -> a
+  -> AVar a
+  -> AVarCallback Unit
+  -> Effect (Effect Unit)
+windowPut strategy value avar cb =
+  case strategy (_pendingPuts avar) of
+    -- Do nothing with the queue
+    Ignore -> pure $ pure unit
+    -- Propagate an exception to the callback
+    Fail e -> do
+      cb $ Left e
+      pure $ pure unit
+    -- Kill the internal queue and propagate the exception
+    Halt e -> do
+      kill e avar
+      cb $ Left e
+      pure $ pure unit
+    -- Push callback onto the head
+    PushHead -> Fn.runFn4 _consVar ffiUtil value avar cb
+    -- Push callback onto the tail
+    PushTail -> Fn.runFn4 _snocVar ffiUtil value avar cb
+    -- Drop the head, and push onto the tail
+    DropHead e -> do
+      void $ Fn.runFn3 _tailPuts ffiUtil e avar
+      Fn.runFn4 _snocVar ffiUtil value avar cb
+    -- Drop the tail, and push onto the head
+    DropTail e -> do
+      void $ Fn.runFn3 _initPuts ffiUtil e avar
+      Fn.runFn4 _consVar ffiUtil value avar cb
+    -- Replace the head
+    SwapHead e -> do
+      void $ Fn.runFn3 _tailPuts ffiUtil e avar
+      Fn.runFn4 _consVar ffiUtil value avar cb
+    -- Replace the tail
+    SwapTail e -> do
+      void $ Fn.runFn3 _initPuts ffiUtil e avar
+      Fn.runFn4 _snocVar ffiUtil value avar cb
 
 -- | Attempts to synchronously fill an AVar. If the AVar is already filled,
 -- | this will do nothing. Returns true or false depending on if it succeeded.
@@ -101,13 +158,17 @@ isKilled = case _ of
 
 foreign import _newVar ∷ ∀ a. a → Effect (AVar a)
 foreign import _killVar ∷ ∀ a. Fn.Fn3 FFIUtil Error (AVar a) (Effect Unit)
-foreign import _putVar ∷ ∀ a. Fn.Fn4 FFIUtil a (AVar a) (AVarCallback Unit) (Effect (Effect Unit))
+foreign import _snocVar ∷ ∀ a. Fn.Fn4 FFIUtil a (AVar a) (AVarCallback Unit) (Effect (Effect Unit))
+foreign import _consVar ∷ ∀ a. Fn.Fn4 FFIUtil a (AVar a) (AVarCallback Unit) (Effect (Effect Unit))
+foreign import _initPuts ∷ ∀ a. Fn.Fn3 FFIUtil Error (AVar a) (Effect (Maybe a))
+foreign import _tailPuts ∷ ∀ a. Fn.Fn3 FFIUtil Error (AVar a) (Effect (Maybe a))
 foreign import _tryPutVar ∷ ∀ a. Fn.Fn3 FFIUtil a (AVar a) (Effect Boolean)
 foreign import _takeVar ∷ ∀ a. Fn.Fn3 FFIUtil (AVar a) (AVarCallback a) (Effect (Effect Unit))
 foreign import _tryTakeVar ∷ ∀ a. Fn.Fn2 FFIUtil (AVar a) (Effect (Maybe a))
 foreign import _readVar ∷ ∀ a. Fn.Fn3 FFIUtil (AVar a) (AVarCallback a) (Effect (Effect Unit))
 foreign import _tryReadVar ∷ ∀ a. Fn.Fn2 FFIUtil (AVar a) (Effect (Maybe a))
 foreign import _status ∷ ∀ a. Fn.Fn2 FFIUtil (AVar a) (Effect (AVarStatus a))
+foreign import _pendingPuts :: ∀ a. AVar a -> Int
 
 type FFIUtil =
   { left ∷ ∀ a b. a → Either a b


### PR DESCRIPTION
please note that the window strategy is based on the number of pending puts. Also note that the `DropHead` strategy drops the head of the pending puts, but doesn't touch the current value of the AVar. In other words, if DropHead is used to achieve a sliding window, and if the first take/read is called after more than window-width number of puts, the effects of the very first put cannot be dropped/undone. The first put takes effect eagerly, and I have not changed that behaviour.